### PR TITLE
Fix redundant package name in env

### DIFF
--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -6,7 +6,6 @@ dependencies:
 - python=3.5
 - pip:
   - chainer==3.0.0
-  - chainercv
   - cupy==2.1.0
   - chainercv==0.7.0.0
   - pyyaml==3.12


### PR DESCRIPTION
Conda will not install unless this is fixed

just merge when approved