### PR TITLE
Return empty bbox instead of nothing if no bbox detected

### DIFF
--- a/multibuildingdetector/readers/xmldataset.py
+++ b/multibuildingdetector/readers/xmldataset.py
@@ -53,6 +53,8 @@ class XMLDataset(chainer.dataset.DatasetMixin):
                 name = obj.find('name').text.lower().strip()
                 label.append(LABEL_NAMES.index(name))
         except FileNotFoundError:
+            # No buildings present in this image,
+            # but dimensions have to be consistent
             bbox.append([0, 0, 0, 0])
             label.append(LABEL_NAMES.index('none'))
         bbox = np.stack(bbox).astype(np.float32)

--- a/multibuildingdetector/readers/xmldataset.py
+++ b/multibuildingdetector/readers/xmldataset.py
@@ -13,7 +13,8 @@ LABEL_NAMES = ('other',
                'funkturm',
                'reichstag',
                'rotesrathaus',
-               'siegessaeule')
+               'siegessaeule',
+               'none')
 
 
 class XMLDataset(chainer.dataset.DatasetMixin):
@@ -52,8 +53,8 @@ class XMLDataset(chainer.dataset.DatasetMixin):
                 name = obj.find('name').text.lower().strip()
                 label.append(LABEL_NAMES.index(name))
         except FileNotFoundError:
-            bbox.append([])
-            label.append([])
+            bbox.append([0, 0, 0, 0])
+            label.append(LABEL_NAMES.index('none'))
         bbox = np.stack(bbox).astype(np.float32)
         label = np.stack(label).astype(np.int32)
 


### PR DESCRIPTION
Currently, the detection_voc_evaluator breaks when it wants to tst, this is due to the dataset not returning the right format when not finding any boxes (for testing). The test and actual prediction have to have the same data format, if the actual prediction has a (or more) bbox and the test has none, numpy cannot concatenate those arrays.
Having one extra category and a bounding box wiht no dimension should fix this and hopefully not impact the accuracy.

Merge when reviewed.