### PR TITLE
[WIP] Use cupy for color conversion

### DIFF
--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -9,4 +9,3 @@ dependencies:
   - cupy==2.1.0
   - chainercv==0.7.0.0
   - pyyaml==3.12
-  - matplotlib==2.1.0

--- a/multibuildingdetector/transforms/augmentation.py
+++ b/multibuildingdetector/transforms/augmentation.py
@@ -6,7 +6,7 @@ from chainercv import transforms
 from chainercv.links.model.ssd import random_crop_with_bbox_constraints, \
     resize_with_random_interpolation
 
-from color_conv import rgb_to_hsv, hsv_to_rgb
+from .color_conv import rgb_to_hsv, hsv_to_rgb
 
 
 def random_distort(

--- a/multibuildingdetector/transforms/augmentation.py
+++ b/multibuildingdetector/transforms/augmentation.py
@@ -1,11 +1,12 @@
 import copy
 import numpy as np
 import random
-import matplotlib
 
 from chainercv import transforms
 from chainercv.links.model.ssd import random_crop_with_bbox_constraints, \
     resize_with_random_interpolation
+
+from color_conv import rgb_to_hsv, hsv_to_rgb
 
 
 def random_distort(
@@ -75,21 +76,21 @@ def random_distort(
 
     def saturation(cv_img, low, high):
         if random.randrange(2):
-            cv_img = matplotlib.colors.rgb_to_hsv(cv_img)
+            cv_img = rgb_to_hsv(cv_img)
             cv_img[:, :, 1] = convert(
                 cv_img[:, :, 1],
                 alpha=random.uniform(low, high))
-            return matplotlib.colors.hsv_to_rgb(cv_img)
+            return hsv_to_rgb(cv_img)
         else:
             return cv_img
 
     def hue(cv_img, delta):
         if random.randrange(2):
-            cv_img = matplotlib.colors.rgb_to_hsv(cv_img)
+            cv_img = rgb_to_hsv(cv_img)
             cv_img[:, :, 0] = (
                 cv_img[:, :, 0].astype(int) +
                 random.randint(-delta, delta)) % 180
-            return matplotlib.colors.hsv_to_rgb(cv_img)
+            return hsv_to_rgb(cv_img)
         else:
             return cv_img
 

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -26,7 +26,7 @@ def hsv_to_rgb(hsv):
     v = hsv[:, :, 2]
 
     hi = cp.dstack([hi, hi, hi]).astype(cp.uint8) % 6
-    out = cp.choose(hi, cp.array([cp.dstack((v, t, p)),
+    out = cp.choose(hi, cp.stack([cp.dstack((v, t, p)),
                                   cp.dstack((q, v, p)),
                                   cp.dstack((p, v, t)),
                                   cp.dstack((p, q, v)),

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -52,38 +52,60 @@ def rgb_to_hsv(rgb):
     ----------
     .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
     """
-    delta = cp.array(rgb.ptp(-1))
+    try:
+        delta = cp.array(rgb.ptp(-1))
+        rgb = cp.array(rgb)
+        out = cp.empty_like(rgb)
+    except:
+        print('Error in init')
+
     # -- V channel
-    out_v = cp.array(rgb.max(-1))
-    rgb = cp.array(rgb)
-    out = cp.empty_like(rgb)
+    out_v = rgb.max(-1)
 
     # -- S channel
     # Ignore warning for zero divided by zero
-    out_s = delta / out_v
-    out_s[delta == 0.] = 0.
+    try:
+        out_s = delta / out_v
+        out_s[delta == 0.] = 0.
+    except:
+        print('Error in ^s')
 
     # -- H channel
     # red is max
-    idx = (rgb[:, :, 0] == out_v)
-    out[idx][:, 0] = (rgb[idx][:, 1] - rgb[idx][:, 2]) / delta[idx]
+    try:
+        idx = (rgb[:, :, 0] == out_v)
+        out[idx][:, 0] = (rgb[idx][:, 1] - rgb[idx][:, 2]) / delta[idx]
+    except:
+        print('Error in red')
 
     # green is max
-    idx = (rgb[:, :, 1] == out_v)
-    out[idx][:, 0] = 2. + (rgb[idx][:, 2] - rgb[idx][:, 0]) / delta[idx]
+    try:
+        idx = (rgb[:, :, 1] == out_v)
+        out[idx][:, 0] = 2. + (rgb[idx][:, 2] - rgb[idx][:, 0]) / delta[idx]
+    except:
+        print('Error in green')
 
     # blue is max
-    idx = (rgb[:, :, 2] == out_v)
-    out[idx][:, 0] = 4. + (rgb[idx][:, 0] - rgb[idx][:, 1]) / delta[idx]
-    out_h = (out[:, :, 0] / 6.) % 1.
-    out_h[delta == 0.] = 0.
+    try:
+        idx = (rgb[:, :, 2] == out_v)
+        out[idx][:, 0] = 4. + (rgb[idx][:, 0] - rgb[idx][:, 1]) / delta[idx]
+        out_h = (out[:, :, 0] / 6.) % 1.
+        out_h[delta == 0.] = 0.
+    except:
+        print('Error in blue')
 
     # -- output
-    out[:, :, 0] = out_h
-    out[:, :, 1] = out_s
-    out[:, :, 2] = out_v
+    try:
+        out[:, :, 0] = out_h
+        out[:, :, 1] = out_s
+        out[:, :, 2] = out_v
+    except:
+        print('Error in out')
 
     # remove NaN
-    out[cp.isnan(out)] = 0
+    try:
+        out[cp.isnan(out)] = 0
+    except:
+        print('Error in nan')
 
     return cp.asnumpy(out)

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -1,7 +1,7 @@
 import cupy as cp
 
 
-def hsv2rgb(hsv):
+def hsv_to_rgb(hsv):
     """HSV to RGB color space conversion.
     Parameters
     ----------
@@ -36,7 +36,7 @@ def hsv2rgb(hsv):
     return cp.asnumpy(out)
 
 
-def rgb2hsv(rgb):
+def rgb_to_hsv(rgb):
     """RGB to HSV color space conversion.
     Parameters
     ----------

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -52,7 +52,7 @@ def rgb_to_hsv(rgb):
     ----------
     .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
     """
-    delta = rgb.ptp(-1)
+    delta = cp.array(rgb.ptp(-1))
     rgb = cp.array(rgb)
     out = cp.empty_like(rgb)
 

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -52,67 +52,39 @@ def rgb_to_hsv(rgb):
     ----------
     .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
     """
-    try:
-        delta = cp.array(rgb.ptp(-1))
-        rgb = cp.array(rgb)
-        out = cp.empty_like(rgb)
-    except:
-        print('Error in init')
-        return rgb
+    delta = cp.array(rgb.ptp(-1))
+    rgb = cp.array(rgb)
+    out = cp.empty_like(rgb)
 
     # -- V channel
     out_v = rgb.max(-1)
 
     # -- S channel
     # Ignore warning for zero divided by zero
-    try:
-        out_s = delta / out_v
-        out_s[delta == 0.] = 0.
-    except:
-        print('Error in s')
-        return cp.asnumpy(rgb)
+    out_s = delta / out_v
+    out_s[delta == 0.] = 0.
 
     # -- H channel
     # red is max
-    try:
-        idx = (rgb[:, :, 0] == out_v)
-        out[idx][:, 0] = (rgb[idx][:, 1] - rgb[idx][:, 2]) / delta[idx]
-    except:
-        print('Error in red')
-        return cp.asnumpy(rgb)
+    idx = (rgb[:, :, 0] == out_v)
+    out[idx][:, 0] = (rgb[idx][:, 1] - rgb[idx][:, 2]) / delta[idx]
 
     # green is max
-    try:
-        idx = (rgb[:, :, 1] == out_v)
-        out[idx][:, 0] = 2. + (rgb[idx][:, 2] - rgb[idx][:, 0]) / delta[idx]
-    except:
-        print('Error in green')
-        return cp.asnumpy(rgb)
+    idx = (rgb[:, :, 1] == out_v)
+    out[idx][:, 0] = 2. + (rgb[idx][:, 2] - rgb[idx][:, 0]) / delta[idx]
 
     # blue is max
-    try:
-        idx = (rgb[:, :, 2] == out_v)
-        out[idx][:, 0] = 4. + (rgb[idx][:, 0] - rgb[idx][:, 1]) / delta[idx]
-        out_h = (out[:, :, 0] / 6.) % 1.
-        out_h[delta == 0.] = 0.
-    except:
-        print('Error in blue')
-        return cp.asnumpy(rgb)
+    idx = (rgb[:, :, 2] == out_v)
+    out[idx][:, 0] = 4. + (rgb[idx][:, 0] - rgb[idx][:, 1]) / delta[idx]
+    out_h = (out[:, :, 0] / 6.) % 1.
+    out_h[delta == 0.] = 0.
 
     # -- output
-    try:
-        out[:, :, 0] = out_h
-        out[:, :, 1] = out_s
-        out[:, :, 2] = out_v
-    except:
-        print('Error in out')
-        return cp.asnumpy(rgb)
+    out[:, :, 0] = out_h
+    out[:, :, 1] = out_s
+    out[:, :, 2] = out_v
 
     # remove NaN
-    try:
-        out[cp.isnan(out)] = 0
-    except:
-        print('Error in nan')
-        return cp.asnumpy(rgb)
+    out[cp.isnan(out)] = 0
 
     return cp.asnumpy(out)

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -58,6 +58,7 @@ def rgb_to_hsv(rgb):
         out = cp.empty_like(rgb)
     except:
         print('Error in init')
+        return rgb
 
     # -- V channel
     out_v = rgb.max(-1)
@@ -68,7 +69,8 @@ def rgb_to_hsv(rgb):
         out_s = delta / out_v
         out_s[delta == 0.] = 0.
     except:
-        print('Error in ^s')
+        print('Error in s')
+        return cp.asnumpy(rgb)
 
     # -- H channel
     # red is max
@@ -77,6 +79,7 @@ def rgb_to_hsv(rgb):
         out[idx][:, 0] = (rgb[idx][:, 1] - rgb[idx][:, 2]) / delta[idx]
     except:
         print('Error in red')
+        return cp.asnumpy(rgb)
 
     # green is max
     try:
@@ -84,6 +87,7 @@ def rgb_to_hsv(rgb):
         out[idx][:, 0] = 2. + (rgb[idx][:, 2] - rgb[idx][:, 0]) / delta[idx]
     except:
         print('Error in green')
+        return cp.asnumpy(rgb)
 
     # blue is max
     try:
@@ -93,6 +97,7 @@ def rgb_to_hsv(rgb):
         out_h[delta == 0.] = 0.
     except:
         print('Error in blue')
+        return cp.asnumpy(rgb)
 
     # -- output
     try:
@@ -101,11 +106,13 @@ def rgb_to_hsv(rgb):
         out[:, :, 2] = out_v
     except:
         print('Error in out')
+        return cp.asnumpy(rgb)
 
     # remove NaN
     try:
         out[cp.isnan(out)] = 0
     except:
         print('Error in nan')
+        return cp.asnumpy(rgb)
 
     return cp.asnumpy(out)

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -53,11 +53,10 @@ def rgb_to_hsv(rgb):
     .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
     """
     delta = cp.array(rgb.ptp(-1))
-    rgb = cp.array(rgb)
-    out = cp.empty_like(rgb)
-
     # -- V channel
     out_v = rgb.max(-1)
+    rgb = cp.array(rgb)
+    out = cp.empty_like(rgb)
 
     # -- S channel
     # Ignore warning for zero divided by zero

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -67,15 +67,15 @@ def rgb_to_hsv(rgb):
     # -- H channel
     # red is max
     idx = (rgb[:, :, 0] == out_v)
-    out[idx, 0] = (rgb[idx, 1] - rgb[idx, 2]) / delta[idx]
+    out[idx][:, 0] = (rgb[idx][:, 1] - rgb[idx][:, 2]) / delta[idx]
 
     # green is max
-    idx = (rgb[:, :, 1] == out_v)
-    out[idx, 0] = 2. + (rgb[idx, 2] - rgb[idx, 0]) / delta[idx]
+    idx = (rgb[:, :][:, 1] == out_v)
+    out[idx][:, 0] = 2. + (rgb[idx][:, 2] - rgb[idx][:, 0]) / delta[idx]
 
     # blue is max
     idx = (rgb[:, :, 2] == out_v)
-    out[idx, 0] = 4. + (rgb[idx, 0] - rgb[idx, 1]) / delta[idx]
+    out[idx][:, 0] = 4. + (rgb[idx][:, 0] - rgb[idx][:, 1]) / delta[idx]
     out_h = (out[:, :, 0] / 6.) % 1.
     out_h[delta == 0.] = 0.
 

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -52,6 +52,7 @@ def rgb_to_hsv(rgb):
     ----------
     .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
     """
+    delta = rgb.ptp(-1)
     rgb = cp.array(rgb)
     out = cp.empty_like(rgb)
 
@@ -59,9 +60,7 @@ def rgb_to_hsv(rgb):
     out_v = rgb.max(-1)
 
     # -- S channel
-    delta = rgb.ptp(-1)
     # Ignore warning for zero divided by zero
-    old_settings = cp.seterr(invalid='ignore')
     out_s = delta / out_v
     out_s[delta == 0.] = 0.
 
@@ -79,8 +78,6 @@ def rgb_to_hsv(rgb):
     out[idx, 0] = 4. + (rgb[idx, 0] - rgb[idx, 1]) / delta[idx]
     out_h = (out[:, :, 0] / 6.) % 1.
     out_h[delta == 0.] = 0.
-
-    cp.seterr(**old_settings)
 
     # -- output
     out[:, :, 0] = out_h

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -1,0 +1,93 @@
+import cupy as cp
+
+
+def hsv2rgb(hsv):
+    """HSV to RGB color space conversion.
+    Parameters
+    ----------
+    hsv : numpy array
+        The image in HSV format, in a 3-D array of shape ``(.., .., 3)``.
+    Returns
+    -------
+    out : ndarray
+        The image in RGB format, in a 3-D array of shape ``(.., .., 3)``.
+    Conversion between RGB and HSV color spaces results in some loss of
+    precision, due to integer arithmetic and rounding [1]_.
+    References
+    ----------
+    .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
+    """
+    hsv = cp.array(hsv)
+    hi = cp.floor(hsv[:, :, 0] * 6)
+    f = hsv[:, :, 0] * 6 - hi
+    p = hsv[:, :, 2] * (1 - hsv[:, :, 1])
+    q = hsv[:, :, 2] * (1 - f * hsv[:, :, 1])
+    t = hsv[:, :, 2] * (1 - (1 - f) * hsv[:, :, 1])
+    v = hsv[:, :, 2]
+
+    hi = cp.dstack([hi, hi, hi]).astype(cp.uint8) % 6
+    out = cp.choose(hi, [cp.dstack((v, t, p)),
+                         cp.dstack((q, v, p)),
+                         cp.dstack((p, v, t)),
+                         cp.dstack((p, q, v)),
+                         cp.dstack((t, p, v)),
+                         cp.dstack((v, p, q))])
+
+    return cp.asnumpy(out)
+
+
+def rgb2hsv(rgb):
+    """RGB to HSV color space conversion.
+    Parameters
+    ----------
+    rgb : numpy array
+        The image in RGB format, in a 3-D array of shape ``(.., .., 3)``.
+    Returns
+    -------
+    out : ndarray
+        The image in HSV format, in a 3-D array of shape ``(.., .., 3)``.
+    Conversion between RGB and HSV color spaces results in some loss of
+    precision, due to integer arithmetic and rounding [1]_.
+    References
+    ----------
+    .. [1] http://en.wikipedia.org/wiki/HSL_and_HSV
+    """
+    rgb = cp.array(rgb)
+    out = cp.empty_like(rgb)
+
+    # -- V channel
+    out_v = rgb.max(-1)
+
+    # -- S channel
+    delta = rgb.ptp(-1)
+    # Ignore warning for zero divided by zero
+    old_settings = cp.seterr(invalid='ignore')
+    out_s = delta / out_v
+    out_s[delta == 0.] = 0.
+
+    # -- H channel
+    # red is max
+    idx = (rgb[:, :, 0] == out_v)
+    out[idx, 0] = (rgb[idx, 1] - rgb[idx, 2]) / delta[idx]
+
+    # green is max
+    idx = (rgb[:, :, 1] == out_v)
+    out[idx, 0] = 2. + (rgb[idx, 2] - rgb[idx, 0]) / delta[idx]
+
+    # blue is max
+    idx = (rgb[:, :, 2] == out_v)
+    out[idx, 0] = 4. + (rgb[idx, 0] - rgb[idx, 1]) / delta[idx]
+    out_h = (out[:, :, 0] / 6.) % 1.
+    out_h[delta == 0.] = 0.
+
+    cp.seterr(**old_settings)
+
+    # -- output
+    out[:, :, 0] = out_h
+    out[:, :, 1] = out_s
+    out[:, :, 2] = out_v
+
+    # remove NaN
+    out[cp.isnan(out)] = 0
+
+    return cp.asnumpy(out)

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -26,12 +26,12 @@ def hsv_to_rgb(hsv):
     v = hsv[:, :, 2]
 
     hi = cp.dstack([hi, hi, hi]).astype(cp.uint8) % 6
-    out = cp.choose(hi, [cp.dstack((v, t, p)),
-                         cp.dstack((q, v, p)),
-                         cp.dstack((p, v, t)),
-                         cp.dstack((p, q, v)),
-                         cp.dstack((t, p, v)),
-                         cp.dstack((v, p, q))])
+    out = cp.choose(hi, cp.array([cp.dstack((v, t, p)),
+                                  cp.dstack((q, v, p)),
+                                  cp.dstack((p, v, t)),
+                                  cp.dstack((p, q, v)),
+                                  cp.dstack((t, p, v)),
+                                  cp.dstack((v, p, q))]))
 
     return cp.asnumpy(out)
 
@@ -70,7 +70,7 @@ def rgb_to_hsv(rgb):
     out[idx][:, 0] = (rgb[idx][:, 1] - rgb[idx][:, 2]) / delta[idx]
 
     # green is max
-    idx = (rgb[:, :][:, 1] == out_v)
+    idx = (rgb[:, :, 1] == out_v)
     out[idx][:, 0] = 2. + (rgb[idx][:, 2] - rgb[idx][:, 0]) / delta[idx]
 
     # blue is max

--- a/multibuildingdetector/transforms/color_conv.py
+++ b/multibuildingdetector/transforms/color_conv.py
@@ -54,7 +54,7 @@ def rgb_to_hsv(rgb):
     """
     delta = cp.array(rgb.ptp(-1))
     # -- V channel
-    out_v = rgb.max(-1)
+    out_v = cp.array(rgb.max(-1))
     rgb = cp.array(rgb)
     out = cp.empty_like(rgb)
 


### PR DESCRIPTION
I used cupy for color conversion instead of matlab or opencv.
Seemed to work on the GPU for now, but I think this actually slows us down. (I would name some numbers, but I got an error unrelated to this due to current dataset changes it seems, so this is to be tested once #5 is finally merged)

Reason for the slowdown is most probably super frequent context switch (copy img to GPU, convert it, copy back and then the same procedure again, so 4 copy procedures for every image.)

TODO:
In case we don't want to train on the GPU (because we seem to be supporting it), we still have to use matplotlib, I didn't add a parameter for this yet.

Can we maybe do the whole augmentation on the GPU and save 2 copy procedures? Most likely, but first we need to know how slow this really is.

(I'm looking at you, #5 )